### PR TITLE
Remove the focus lost screen

### DIFF
--- a/Project.xml
+++ b/Project.xml
@@ -51,6 +51,7 @@
 	<!-- ______________________________ Haxedefines _____________________________ -->
 
 	<haxedef name="FLX_NO_HEALTH" />
+	<haxedef name="FLX_NO_FOCUS_LOST_SCREEN" />
 
 	<haxedef name="FLX_NO_MOUSE" if="mobile" />
 	<haxedef name="FLX_NO_KEYBOARD" if="mobile" />


### PR DESCRIPTION
The screenshot below shows what I mean by "focus lost screen". This PR gets rid of that screen.

<img width="1222" height="896" alt="Screenshot 2026-02-17 122249" src="https://github.com/user-attachments/assets/6fa6d5cd-6d75-4e72-bc72-482748f4fc08" />